### PR TITLE
feat(query): add --test-target filter for test items by parent target

### DIFF
--- a/src/reportportal/ap.py
+++ b/src/reportportal/ap.py
@@ -174,6 +174,11 @@ def _add_query_arguments(subparsers: argparse.ArgumentParser, defaults: dict) ->
         default=None
     )
     parser.add_argument(
+        "--test-target",
+        help="Filter test items by parent test target name (e.g. 'kuadrant' to show only tests under the kuadrant target)",
+        default=None
+    )
+    parser.add_argument(
         "--status",
         choices=["PASSED", "FAILED", "SKIPPED", "INTERRUPTED", "IN_PROGRESS"],
         help="Filter test items by status (only applies when --launch-id is specified)",

--- a/src/reportportal/rp_query.py
+++ b/src/reportportal/rp_query.py
@@ -457,8 +457,34 @@ def _build_filter_description(options: Namespace) -> List[str]:
     if hasattr(options, 'attribute_regex') and options.attribute_regex:
         for attr_regex in options.attribute_regex:
             filters.append(f"attribute_regex=/{attr_regex}/")
+    if hasattr(options, 'test_target') and options.test_target:
+        filters.append(f"test_target={options.test_target}")
 
     return filters
+
+
+def _resolve_test_target(client: 'ReportPortalAPIClient', launch_id: str, target_name: str) -> Optional[str]:
+    """
+    Resolve a test target name to its parent item ID.
+
+    Args:
+        client: ReportPortal API client
+        launch_id: Launch ID to search within
+        target_name: Test target name to find
+
+    Returns:
+        Parent item ID as string if found, None otherwise
+    """
+    # TODO: rewrite to use fetch_test_items once it supports additional filters (see https://github.com/Kuadrant/testsuite-rptool/issues/2)
+    parent_items = client.get_test_items(
+        launch_id,
+        filters={'filter.eq.name': target_name, 'filter.eq.type': 'TEST'}
+    )
+    if not parent_items:
+        return None
+    parent_id = parent_items[0].get('id')
+    logger.info(f"Found test target '{target_name}' with ID: {parent_id}")
+    return parent_id
 
 
 # =============================================================================
@@ -504,6 +530,15 @@ def run_query(options: Namespace) -> int:
         # Query test items for specific launch
         logger.info(f"Querying test items for launch ID: {options.launch_id}{filter_msg}")
 
+        # Resolve test target to parent ID if specified
+        test_target = getattr(options, 'test_target', None)
+        parent_id = None
+        if test_target:
+            parent_id = _resolve_test_target(client, options.launch_id, test_target)
+            if parent_id is None:
+                logger.error(f"No test target found with name: {test_target}")
+                return 1
+
         # Fetch launch info for header (unless names_only mode)
         if not filter_opts['names_only']:
             try:
@@ -516,6 +551,10 @@ def run_query(options: Namespace) -> int:
         if items is None:
             logger.error("Failed to retrieve test items")
             return 1
+        # Filter by parent if test target was specified
+        # TODO: replace local filtering with ReportPortal API filter parameter once fetch_test_items supports it (see https://github.com/Kuadrant/testsuite-rptool/issues/2)
+        if parent_id:
+            items = [item for item in items if item.get('parent') == parent_id]
 
         list_test_items(
             items,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                   
  - Adds `--test-target` CLI option to the `query` subcommand for filtering test items by parent test target name                                                                                                                                              
  - Resolves the target name to a parent TEST item ID and filters results to only show items under that target                                                                                                                                                 
  - Useful for narrowing down query results in launches with multiple test targets (e.g. `--test-target kuadrant`) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --test-target option to the query command to filter returned test items by parent test target name.
  * The specified test target is resolved and validated before a query runs; the command exits with an error if the target cannot be found.
  * Query results are further narrowed to include only items associated with the resolved parent test target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->