### PR TITLE
feat: support pytest-rerunfailures retry data in ReportPortal imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ venv/
 env/
 ENV/
 
+# uv
+uv.lock
+
 # Env file
 rp_env.sh
 

--- a/src/reportportal/property_enums.py
+++ b/src/reportportal/property_enums.py
@@ -11,6 +11,7 @@ class ReportPortalProperties(Enum):
     LAUNCH_DESCRIPTION = '__rp_launch_description'
     SUITE_DESCRIPTION = '__rp_suite_description'
     CASE_DESCRIPTION = '__rp_case_description'
+    RERUNS = '__rp_reruns'
     
     @classmethod
     def is_rp_property(cls, key: str) -> bool:

--- a/src/reportportal/property_processor.py
+++ b/src/reportportal/property_processor.py
@@ -19,6 +19,7 @@ class CasePropertyResult:
     description: Optional[str] = None
     reruns: int = 0
     rerun_messages: List[str] = field(default_factory=list)
+    rerun_outputs: List[str] = field(default_factory=list)
 
 
 class PropertyFilter:
@@ -103,6 +104,10 @@ class PropertyFilter:
             elif key and key.startswith('__rp_rerun_') and key.endswith('_message'):
                 result.rerun_messages.append(value or "")
                 logger.debug(f"Extracted rerun message: {key}")
+
+            elif key and key.startswith('__rp_rerun_') and key.endswith('_output'):
+                result.rerun_outputs.append(value or "")
+                logger.debug(f"Extracted rerun output: {key}")
 
             elif not ReportPortalProperties.is_rp_property(key):
                 # Keep non-RP properties as regular attributes

--- a/src/reportportal/property_processor.py
+++ b/src/reportportal/property_processor.py
@@ -5,10 +5,20 @@ This module handles filtering and processing of test properties,
 including ReportPortal-specific metadata extraction.
 """
 
+from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Tuple
 from loguru import logger
 
 from .property_enums import ReportPortalProperties
+
+
+@dataclass
+class CasePropertyResult:
+    """Result of filtering test case properties."""
+    properties: List[Dict[str, str]] = field(default_factory=list)
+    description: Optional[str] = None
+    reruns: int = 0
+    rerun_messages: List[str] = field(default_factory=list)
 
 
 class PropertyFilter:
@@ -58,39 +68,50 @@ class PropertyFilter:
         
         return filtered_properties, suite_description, launch_description
     
-    def filter_case_properties(self, properties: List[Dict[str, str]]) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    def filter_case_properties(self, properties: List[Dict[str, str]]) -> CasePropertyResult:
         """
         Filter test case properties and extract description metadata.
-        
+
         Args:
             properties: List of property dictionaries
-            
+
         Returns:
-            Tuple of (filtered_properties, case_description)
+            CasePropertyResult with filtered properties, description, and rerun info
         """
-        filtered_properties = []
-        case_description = None
-        
+        result = CasePropertyResult()
+
         # Handle None or empty input
         if not properties:
-            return filtered_properties, case_description
-        
+            return result
+
         for prop in properties:
             key = prop.get('key')
             value = prop.get('value')
-            
+
             if key == ReportPortalProperties.CASE_DESCRIPTION.value:
-                case_description = value
+                result.description = value
                 logger.debug("Extracted case description from test properties")
-                
+
+            elif key == ReportPortalProperties.RERUNS.value:
+                try:
+                    result.reruns = max(0, int(value))
+                except (TypeError, ValueError):
+                    logger.warning(f"Invalid rerun count value: {value!r}. Defaulting to 0.")
+                    result.reruns = 0
+                logger.debug(f"Extracted rerun count: {result.reruns}")
+
+            elif key and key.startswith('__rp_rerun_') and key.endswith('_message'):
+                result.rerun_messages.append(value or "")
+                logger.debug(f"Extracted rerun message: {key}")
+
             elif not ReportPortalProperties.is_rp_property(key):
                 # Keep non-RP properties as regular attributes
-                filtered_properties.append(prop)
+                result.properties.append(prop)
             else:
                 # Log other RP properties that are being filtered out
                 logger.debug(f"Filtering out RP property: {key}")
-        
-        return filtered_properties, case_description
+
+        return result
     
     def promote_info_collector_properties(self, suite_name: str, suite_properties: List[Dict[str, str]], 
                                         launch_description: Optional[str]) -> Tuple[Optional[List[Dict[str, str]]], Optional[str]]:

--- a/src/reportportal/reportportal_client_wrapper.py
+++ b/src/reportportal/reportportal_client_wrapper.py
@@ -247,7 +247,8 @@ class ReportPortalClientWrapper:
     def start_test_case(self, name: str, start_time: str, parent_id: str,
                        attributes: Optional[List[Dict]] = None,
                        description: Optional[str] = None,
-                       code_ref: Optional[str] = None) -> str:
+                       code_ref: Optional[str] = None,
+                       retry: bool = False) -> str:
         """
         Start a test case.
 
@@ -258,6 +259,7 @@ class ReportPortalClientWrapper:
             attributes: Test case attributes
             description: Test case description
             code_ref: Code reference for the test (e.g., "path/to/test.py::test_name")
+            retry: If True, marks this test case as a retry of a previous attempt
 
         Returns:
             Test case item ID
@@ -265,7 +267,7 @@ class ReportPortalClientWrapper:
         if self.dry_run:
             mock_id = self._generate_mock_id()
             logger.info(f"[DRY-RUN] Would start test case '{name}' with ID: {mock_id}")
-            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}")
+            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}")
             return mock_id
 
         if not self.client:
@@ -279,10 +281,11 @@ class ReportPortalClientWrapper:
                 attributes=attributes,
                 description=description,
                 parent_item_id=parent_id,
-                code_ref=code_ref
+                code_ref=code_ref,
+                retry=retry
             )
             logger.debug(f"Started test case '{name}' with ID: {case_id}")
-            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}")
+            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}")
             return case_id
         except Exception as e:
             logger.error(f"Failed to start test case '{name}': {e}")

--- a/src/reportportal/reportportal_client_wrapper.py
+++ b/src/reportportal/reportportal_client_wrapper.py
@@ -248,7 +248,8 @@ class ReportPortalClientWrapper:
                        attributes: Optional[List[Dict]] = None,
                        description: Optional[str] = None,
                        code_ref: Optional[str] = None,
-                       retry: bool = False) -> str:
+                       retry: bool = False,
+                       retry_of: Optional[str] = None) -> str:
         """
         Start a test case.
 
@@ -260,6 +261,7 @@ class ReportPortalClientWrapper:
             description: Test case description
             code_ref: Code reference for the test (e.g., "path/to/test.py::test_name")
             retry: If True, marks this test case as a retry of a previous attempt
+            retry_of: UUID of the original test item this retry references (RP 25.x)
 
         Returns:
             Test case item ID
@@ -267,7 +269,7 @@ class ReportPortalClientWrapper:
         if self.dry_run:
             mock_id = self._generate_mock_id()
             logger.info(f"[DRY-RUN] Would start test case '{name}' with ID: {mock_id}")
-            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}")
+            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}, Retry of: {retry_of}")
             return mock_id
 
         if not self.client:
@@ -282,10 +284,11 @@ class ReportPortalClientWrapper:
                 description=description,
                 parent_item_id=parent_id,
                 code_ref=code_ref,
-                retry=retry
+                retry=retry,
+                retry_of=retry_of
             )
             logger.debug(f"Started test case '{name}' with ID: {case_id}")
-            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}")
+            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}, Retry of: {retry_of}")
             return case_id
         except Exception as e:
             logger.error(f"Failed to start test case '{name}': {e}")

--- a/src/reportportal/writer.py
+++ b/src/reportportal/writer.py
@@ -233,39 +233,53 @@ class RPWriter:
             attributes=suite_properties
         )
     
-    def _create_retry_items(self, test_name: str, code_ref: str, case_result,
-                           suite_id: str, start_time: int, rerun_duration: int) -> None:
+    def _create_failed_attempts(self, test_name: str, case_result,
+                               suite_id: str, start_time: int, rerun_duration: int) -> str:
         """
-        Create retry items for failed rerun attempts.
+        Create all failed rerun attempts before the final test result.
+
+        The first attempt is the original item (retry=False). Subsequent attempts
+        are retries referencing the original via retry_of (RP 25.x).
 
         Args:
             test_name: Full test case name
-            code_ref: Code reference for the test
             case_result: Filtered case property result
             suite_id: Parent suite ID
             start_time: Test case start time
             rerun_duration: Duration allocated per retry attempt
+
+        Returns:
+            UUID of the original (first) test item
         """
+        original_id = None
         for attempt in range(case_result.reruns):
+            is_original = (attempt == 0)
             attempt_start = start_time + (attempt * rerun_duration)
-            retry_id = self.rp_client.start_test_case(
+            item_id = self.rp_client.start_test_case(
                 name=test_name,
                 start_time=str(attempt_start),
                 parent_id=suite_id,
                 attributes=case_result.properties,
                 description=case_result.description,
-                code_ref=code_ref,
-                retry=True
+                code_ref=test_name,
+                retry=not is_original,
+                retry_of=None if is_original else original_id
             )
+            if is_original:
+                original_id = item_id
             if attempt < len(case_result.rerun_messages):
-                self.rp_client.log_message(retry_id, case_result.rerun_messages[attempt], "ERROR")
+                self.rp_client.log_message(item_id, case_result.rerun_messages[attempt], "ERROR")
+            if attempt < len(case_result.rerun_outputs):
+                self.rp_client.log_message(item_id, case_result.rerun_outputs[attempt], "INFO")
             self.rp_client.finish_test_case(
-                retry_id,
+                item_id,
                 end_time=str(attempt_start + rerun_duration),
                 status="FAILED",
                 attributes=case_result.properties
             )
-            logger.debug(f"Created retry {attempt + 1}/{case_result.reruns} for '{test_name}'")
+            logger.debug(f"Created {'original' if is_original else 'retry'} attempt "
+                         f"{attempt + 1}/{case_result.reruns} for '{test_name}'")
+        return original_id
 
     def _process_test_case(self, case_data: dict, suite_id: str, start_time: int) -> int:
         """
@@ -284,29 +298,32 @@ class RPWriter:
             case_data['properties']
         )
 
-        # Generate test case name and code reference (pytest-style)
+        # Generate test case name (pytest-style)
         test_name = f"{case_data['converted_classname']}::{case_data['name']}"
-        code_ref = test_name
 
-        # Create retry items for each rerun attempt before the final result
+        # Create failed rerun attempts before the final result
+        original_id = None
         final_start_time = start_time
         if case_result.reruns > 0:
             rerun_duration = case_data['time'] // (case_result.reruns + 1)
-            self._create_retry_items(test_name, code_ref, case_result, suite_id, start_time, rerun_duration)
+            original_id = self._create_failed_attempts(
+                test_name, case_result, suite_id, start_time, rerun_duration
+            )
             final_start_time = start_time + (case_result.reruns * rerun_duration)
 
-        # Start final test case
+        # Start the final test case (or the only one if no retries)
         case_id = self.rp_client.start_test_case(
             name=test_name,
             start_time=str(final_start_time),
             parent_id=suite_id,
             attributes=case_result.properties,
             description=case_result.description,
-            code_ref=code_ref,
-            retry=case_result.reruns > 0
+            code_ref=test_name,
+            retry=original_id is not None,
+            retry_of=original_id
         )
 
-        # Log test outputs and results
+        # Log test outputs and results for the final attempt
         self.rp_client.log_test_outputs(
             case_id,
             case_data['system_out'],

--- a/src/reportportal/writer.py
+++ b/src/reportportal/writer.py
@@ -233,20 +233,54 @@ class RPWriter:
             attributes=suite_properties
         )
     
+    def _create_retry_items(self, test_name: str, code_ref: str, case_result,
+                           suite_id: str, start_time: int, rerun_duration: int) -> None:
+        """
+        Create retry items for failed rerun attempts.
+
+        Args:
+            test_name: Full test case name
+            code_ref: Code reference for the test
+            case_result: Filtered case property result
+            suite_id: Parent suite ID
+            start_time: Test case start time
+            rerun_duration: Duration allocated per retry attempt
+        """
+        for attempt in range(case_result.reruns):
+            attempt_start = start_time + (attempt * rerun_duration)
+            retry_id = self.rp_client.start_test_case(
+                name=test_name,
+                start_time=str(attempt_start),
+                parent_id=suite_id,
+                attributes=case_result.properties,
+                description=case_result.description,
+                code_ref=code_ref,
+                retry=True
+            )
+            if attempt < len(case_result.rerun_messages):
+                self.rp_client.log_message(retry_id, case_result.rerun_messages[attempt], "ERROR")
+            self.rp_client.finish_test_case(
+                retry_id,
+                end_time=str(attempt_start + rerun_duration),
+                status="FAILED",
+                attributes=case_result.properties
+            )
+            logger.debug(f"Created retry {attempt + 1}/{case_result.reruns} for '{test_name}'")
+
     def _process_test_case(self, case_data: dict, suite_id: str, start_time: int) -> int:
         """
         Process a single test case.
-        
+
         Args:
             case_data: Test case data dictionary
             suite_id: Parent suite ID
             start_time: Test case start time
-            
+
         Returns:
             Test case runtime in milliseconds
         """
         # Filter case properties
-        filtered_props, case_desc = self.property_filter.filter_case_properties(
+        case_result = self.property_filter.filter_case_properties(
             case_data['properties']
         )
 
@@ -254,16 +288,24 @@ class RPWriter:
         test_name = f"{case_data['converted_classname']}::{case_data['name']}"
         code_ref = test_name
 
-        # Start test case
+        # Create retry items for each rerun attempt before the final result
+        final_start_time = start_time
+        if case_result.reruns > 0:
+            rerun_duration = case_data['time'] // (case_result.reruns + 1)
+            self._create_retry_items(test_name, code_ref, case_result, suite_id, start_time, rerun_duration)
+            final_start_time = start_time + (case_result.reruns * rerun_duration)
+
+        # Start final test case
         case_id = self.rp_client.start_test_case(
             name=test_name,
-            start_time=str(start_time),
+            start_time=str(final_start_time),
             parent_id=suite_id,
-            attributes=filtered_props,
-            description=case_desc,
-            code_ref=code_ref
+            attributes=case_result.properties,
+            description=case_result.description,
+            code_ref=code_ref,
+            retry=case_result.reruns > 0
         )
-        
+
         # Log test outputs and results
         self.rp_client.log_test_outputs(
             case_id,
@@ -273,14 +315,14 @@ class RPWriter:
             case_data['errors'],
             case_data['skipped']
         )
-        
+
         # Finish test case
         end_time = start_time + case_data['time']
         self.rp_client.finish_test_case(
             case_id,
             end_time=str(end_time),
             status=case_data['status'],
-            attributes=filtered_props
+            attributes=case_result.properties
         )
-        
+
         return case_data['time']

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -86,15 +86,15 @@ class TestFullReportPortalWorkflow:
         case_ids = []
         for case in test_cases:
             # Filter case properties
-            case_props, case_desc = property_filter.filter_case_properties(case['properties'])
-            
+            case_result = property_filter.filter_case_properties(case['properties'])
+
             # Start test case
             case_id = rp_wrapper.start_test_case(
                 name=case['name'],
                 start_time=suite_data['timestamp'],  # Using suite timestamp for simplicity
                 parent_id=suite_id,
-                attributes=case_props,
-                description=case_desc
+                attributes=case_result.properties,
+                description=case_result.description
             )
             case_ids.append(case_id)
             
@@ -113,7 +113,7 @@ class TestFullReportPortalWorkflow:
                 case_id=case_id,
                 end_time=suite_data['timestamp'],  # Using suite timestamp for simplicity
                 status=case['status'],
-                attributes=case_props
+                attributes=case_result.properties
             )
         
         # Finish test suite
@@ -179,29 +179,29 @@ class TestFullReportPortalWorkflow:
         
         # Test passing case
         passing_case = next(case for case in test_cases if case['name'] == 'test_passing')
-        case_props, case_desc = property_filter.filter_case_properties(passing_case['properties'])
+        case_result = property_filter.filter_case_properties(passing_case['properties'])
         expected_case_props = [
             {"key": "color", "value": "green"},
             {"key": "component", "value": "TestComponent"}
         ]
-        assert len(case_props) == 2
+        assert len(case_result.properties) == 2
         for prop in expected_case_props:
-            assert prop in case_props
-        assert case_desc is None
-        
+            assert prop in case_result.properties
+        assert case_result.description is None
+
         # Test failing case with description
         failing_case = next(case for case in test_cases if case['name'] == 'test_failing')
-        case_props, case_desc = property_filter.filter_case_properties(failing_case['properties'])
-        assert len(case_props) == 1
-        assert {"key": "color", "value": "red"} in case_props
-        assert case_desc == "Test case that fails"
-        
+        case_result = property_filter.filter_case_properties(failing_case['properties'])
+        assert len(case_result.properties) == 1
+        assert {"key": "color", "value": "red"} in case_result.properties
+        assert case_result.description == "Test case that fails"
+
         # Test skipped case
         skipped_case = next(case for case in test_cases if case['name'] == 'test_skipped')
-        case_props, case_desc = property_filter.filter_case_properties(skipped_case['properties'])
-        assert len(case_props) == 1
-        assert {"key": "color", "value": "yellow"} in case_props
-        assert case_desc is None
+        case_result = property_filter.filter_case_properties(skipped_case['properties'])
+        assert len(case_result.properties) == 1
+        assert {"key": "color", "value": "yellow"} in case_result.properties
+        assert case_result.description is None
     
     @patch('reportportal.reportportal_client_wrapper.requests.post')
     def test_auto_analysis_integration(self, mock_post):
@@ -293,9 +293,9 @@ class TestFullReportPortalWorkflow:
         assert suite_desc is None
         assert launch_desc is None
         
-        filtered_props, case_desc = property_filter.filter_case_properties([])
-        assert filtered_props == []
-        assert case_desc is None
+        case_result = property_filter.filter_case_properties([])
+        assert case_result.properties == []
+        assert case_result.description is None
 
 
 @pytest.mark.integration
@@ -324,8 +324,8 @@ class TestComponentInteraction:
             assert 'properties' in case
             assert isinstance(case['properties'], list)
             
-            case_props, _ = property_filter.filter_case_properties(case['properties'])
-            assert isinstance(case_props, list)
+            case_result = property_filter.filter_case_properties(case['properties'])
+            assert isinstance(case_result.properties, list)
     
     def test_property_filter_to_client_wrapper_data_flow(self):
         """Test data flow from property filter to client wrapper."""

--- a/tests/unit/test_property_processor.py
+++ b/tests/unit/test_property_processor.py
@@ -75,15 +75,15 @@ class TestPropertyFilter:
             {"key": "__rp_filtered", "value": "should be filtered"}
         ]
         
-        filtered_props, case_desc = filter_obj.filter_case_properties(properties)
-        
+        case_result = filter_obj.filter_case_properties(properties)
+
         # Should keep non-RP properties
-        assert len(filtered_props) == 2
-        assert {"key": "color", "value": "green"} in filtered_props
-        assert {"key": "component", "value": "TestComponent"} in filtered_props
-        
+        assert len(case_result.properties) == 2
+        assert {"key": "color", "value": "green"} in case_result.properties
+        assert {"key": "component", "value": "TestComponent"} in case_result.properties
+
         # Should extract description
-        assert case_desc == "Case description"
+        assert case_result.description == "Case description"
     
     def test_filter_case_properties_no_description(self):
         """Test case property filtering with no description."""
@@ -94,20 +94,47 @@ class TestPropertyFilter:
             {"key": "priority", "value": "high"}
         ]
         
-        filtered_props, case_desc = filter_obj.filter_case_properties(properties)
-        
-        assert len(filtered_props) == 2
-        assert case_desc is None
+        case_result = filter_obj.filter_case_properties(properties)
+
+        assert len(case_result.properties) == 2
+        assert case_result.description is None
     
     def test_filter_case_properties_empty(self):
         """Test case property filtering with empty list."""
         filter_obj = PropertyFilter()
         
-        filtered_props, case_desc = filter_obj.filter_case_properties([])
-        
-        assert filtered_props == []
-        assert case_desc is None
+        case_result = filter_obj.filter_case_properties([])
+
+        assert case_result.properties == []
+        assert case_result.description is None
     
+    def test_filter_case_properties_with_reruns_and_messages(self):
+        """Test case property filtering with rerun metadata."""
+        filter_obj = PropertyFilter()
+
+        properties = [
+            {"key": "__rp_reruns", "value": "2"},
+            {"key": "__rp_rerun_1_message", "value": "first failure"},
+            {"key": "__rp_rerun_2_message", "value": "second failure"},
+            {"key": "component", "value": "TestComponent"},
+        ]
+
+        case_result = filter_obj.filter_case_properties(properties)
+
+        assert case_result.reruns == 2
+        assert case_result.rerun_messages == ["first failure", "second failure"]
+        assert {"key": "component", "value": "TestComponent"} in case_result.properties
+
+    def test_filter_case_properties_with_invalid_reruns_value(self):
+        """Test case property filtering with invalid rerun count."""
+        filter_obj = PropertyFilter()
+
+        properties = [{"key": "__rp_reruns", "value": "not-an-int"}]
+
+        case_result = filter_obj.filter_case_properties(properties)
+
+        assert case_result.reruns == 0
+
     def test_promote_info_collector_properties(self):
         """Test promotion of info-collector properties."""
         filter_obj = PropertyFilter()
@@ -320,8 +347,8 @@ class TestPropertyFilterIntegration:
             {"key": "__rp_internal_tag", "value": "should be filtered"}
         ]
         
-        filtered_props, case_desc = filter_obj.filter_case_properties(case_properties)
-        
+        case_result = filter_obj.filter_case_properties(case_properties)
+
         # Should keep non-RP properties
         expected_props = [
             {"key": "color", "value": "red"},
@@ -329,8 +356,8 @@ class TestPropertyFilterIntegration:
             {"key": "issue", "value": "ISSUE-123"}
         ]
         
-        assert len(filtered_props) == 3
+        assert len(case_result.properties) == 3
         for prop in expected_props:
-            assert prop in filtered_props
-        
-        assert case_desc == "Test case for component X"
+            assert prop in case_result.properties
+
+        assert case_result.description == "Test case for component X"

--- a/tests/unit/test_reportportal_client_wrapper.py
+++ b/tests/unit/test_reportportal_client_wrapper.py
@@ -229,7 +229,8 @@ class TestReportPortalClientWrapper:
             attributes=[{"key": "color", "value": "green"}],
             description="Case description",
             parent_item_id="suite_456",
-            code_ref=None
+            code_ref=None,
+            retry=False
         )
 
     def test_start_test_case_with_code_ref(self):
@@ -255,7 +256,8 @@ class TestReportPortalClientWrapper:
             attributes=[{"key": "color", "value": "green"}],
             description="Case description",
             parent_item_id="suite_456",
-            code_ref="path/to/test.py::test_name"
+            code_ref="path/to/test.py::test_name",
+            retry=False
         )
 
     def test_start_test_case_no_client(self):

--- a/tests/unit/test_reportportal_client_wrapper.py
+++ b/tests/unit/test_reportportal_client_wrapper.py
@@ -230,7 +230,8 @@ class TestReportPortalClientWrapper:
             description="Case description",
             parent_item_id="suite_456",
             code_ref=None,
-            retry=False
+            retry=False,
+            retry_of=None
         )
 
     def test_start_test_case_with_code_ref(self):
@@ -257,7 +258,8 @@ class TestReportPortalClientWrapper:
             description="Case description",
             parent_item_id="suite_456",
             code_ref="path/to/test.py::test_name",
-            retry=False
+            retry=False,
+            retry_of=None
         )
 
     def test_start_test_case_no_client(self):


### PR DESCRIPTION
## Summary    

  - Add support for `pytest-rerunfailures` retry data when importing JUnit XML results into ReportPortal                                                                                                                           
  - Parse `__rp_reruns` and `__rp_rerun_N_message` custom properties from test cases and create corresponding retry items in ReportPortal with `retry=True` flag
  - Fix timeline ordering so retry attempts and the final result don't overlap in ReportPortal's UI                                                                                                                                
                                                                                                                                                                                                                                   
  ## Changes                                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  - **`property_enums.py`** — add `RERUNS` enum value                                                                                                                                                                              
  - **`property_processor.py`** — introduce `CasePropertyResult` dataclass, extract rerun count and messages in `filter_case_properties()`
  - **`reportportal_client_wrapper.py`** — add `retry` parameter to `start_test_case()`                                                                                                                                            
  - **`writer.py`** — extract `_create_retry_items()` method, create retry items with proper sequential timestamps before the final test case result
 
## How it works                                                                                                                                                                                                                  
                                                                                                                                                                                                                                   
  The testsuite's conftest injects `__rp_reruns` and `__rp_rerun_N_message` properties into the JUnit XML for tests that were retried. rptool now parses these and creates individual retry entries in ReportPortal, resulting in  an expandable retry history per test.
                                                                                                                                                                                                                                   
**Note:** The testsuite-side integration (conftest hook that generates the `__rp_reruns` and `__rp_rerun_N_message` properties in JUnit XML) is not yet implemented in the testsuite repository. This PR prepares rptool to    
  consume the data once the testsuite implementation is done.

Closes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for test-case reruns with automatic creation of retry items and propagation of retry status to the final attempt
  * Per-attempt rerun messages/outputs captured and reported
  * Case descriptions and non-ReportPortal attributes extracted and attached to test cases
  * Retry metadata (retry flag and reference to original attempt) included when registering attempts

* **Chores**
  * Added lockfile pattern to .gitignore

* **Tests**
  * Integration and unit tests updated to validate new rerun/result shape and retry behaviour
<!-- end of auto-generated comment: release notes by coderabbit.ai -->