### PR TITLE
FIX(api-client) Handle ReportPortal API timestamp format change

### DIFF
--- a/src/reportportal/rp_api_client.py
+++ b/src/reportportal/rp_api_client.py
@@ -7,6 +7,7 @@ with ReportPortal REST API.
 
 import requests
 from typing import List, Dict, Optional, Any
+from datetime import datetime
 from loguru import logger
 
 
@@ -63,6 +64,59 @@ class ReportPortalAPIClient:
             'Content-type': 'application/json',
             'accept': '*/*'
         }
+
+    @staticmethod
+    def normalize_timestamp(timestamp: Optional[Any]) -> Optional[int]:
+        """
+        Normalize timestamp to Unix milliseconds (integer).
+
+        ReportPortal API changed from returning Unix milliseconds to ISO format strings.
+        This method handles both formats for backward compatibility.
+
+        Args:
+            timestamp: Either ISO format string or Unix milliseconds (int/float)
+
+        Returns:
+            Unix timestamp in milliseconds as integer, or None if input is None
+        """
+        if timestamp is None:
+            return None
+
+        # Already in Unix milliseconds format
+        if isinstance(timestamp, (int, float)):
+            return int(timestamp)
+
+        # ISO format string - convert to Unix milliseconds
+        if isinstance(timestamp, str):
+            try:
+                dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+                return int(dt.timestamp() * 1000)
+            except (ValueError, AttributeError) as e:
+                logger.warning(f"Failed to parse timestamp '{timestamp}': {e}")
+                return None
+
+        return None
+
+    def normalize_timestamps_in_dict(self, data: Dict[str, Any],
+                                     timestamp_fields: List[str] = None) -> Dict[str, Any]:
+        """
+        Normalize timestamp fields in a dictionary.
+
+        Args:
+            data: Dictionary potentially containing timestamp fields
+            timestamp_fields: List of field names to normalize (default: startTime, endTime)
+
+        Returns:
+            Dictionary with normalized timestamps
+        """
+        if timestamp_fields is None:
+            timestamp_fields = ['startTime', 'endTime']
+
+        for field in timestamp_fields:
+            if field in data:
+                data[field] = self.normalize_timestamp(data[field])
+
+        return data
 
     def build_url(self, resource: str, **params) -> str:
         """
@@ -243,7 +297,7 @@ class ReportPortalAPIClient:
             filters: Additional filters as dict (e.g., {'filter.eq.name': 'test'})
 
         Returns:
-            List of launch dictionaries
+            List of launch dictionaries with normalized timestamps (Unix milliseconds)
 
         Raises:
             ReportPortalAPIError: On API errors
@@ -261,6 +315,9 @@ class ReportPortalAPIClient:
         data = self._get(endpoint)
         launches = data.get('content', [])
 
+        # Normalize timestamps in all launches
+        launches = [self.normalize_timestamps_in_dict(launch) for launch in launches]
+
         logger.debug(f"Retrieved {len(launches)} launches")
         return launches
 
@@ -272,14 +329,15 @@ class ReportPortalAPIClient:
             launch_id: Launch UUID
 
         Returns:
-            Launch dictionary
+            Launch dictionary with normalized timestamps (Unix milliseconds)
 
         Raises:
             ReportPortalAPIError: On API errors
         """
         logger.debug(f"Fetching launch {launch_id}")
         endpoint = f'/api/v1/{self.project}/launch/{launch_id}'
-        return self._get(endpoint)
+        launch = self._get(endpoint)
+        return self.normalize_timestamps_in_dict(launch)
 
     # =========================================================================
     # Test Item Operations
@@ -298,7 +356,7 @@ class ReportPortalAPIClient:
             filters: Additional filters (e.g., {'filter.eq.status': 'FAILED'})
 
         Returns:
-            List of test item dictionaries
+            List of test item dictionaries with normalized timestamps (Unix milliseconds)
 
         Raises:
             ReportPortalAPIError: On API errors
@@ -319,6 +377,9 @@ class ReportPortalAPIClient:
         data = self._get(endpoint)
         items = data.get('content', [])
 
+        # Normalize timestamps in all test items
+        items = [self.normalize_timestamps_in_dict(item) for item in items]
+
         logger.debug(f"Retrieved {len(items)} test items")
         return items
 
@@ -330,14 +391,15 @@ class ReportPortalAPIClient:
             item_id: Test item UUID
 
         Returns:
-            Test item dictionary
+            Test item dictionary with normalized timestamps (Unix milliseconds)
 
         Raises:
             ReportPortalAPIError: On API errors
         """
         logger.debug(f"Fetching test item {item_id}")
         endpoint = f'/api/v1/{self.project}/item/{item_id}'
-        return self._get(endpoint)
+        item = self._get(endpoint)
+        return self.normalize_timestamps_in_dict(item)
 
     # =========================================================================
     # Analysis Operations
@@ -391,9 +453,8 @@ def create_api_client(url: str, project: str, token: str) -> ReportPortalAPIClie
         url: ReportPortal URL
         project: ReportPortal project name
         token: ReportPortal API token
-        logger: Optional logger instance
 
     Returns:
         Configured ReportPortalAPIClient instance
     """
-    return ReportPortalAPIClient(url, project, token, logger=logger)
+    return ReportPortalAPIClient(url, project, token)

--- a/src/reportportal/rp_api_client.py
+++ b/src/reportportal/rp_api_client.py
@@ -92,9 +92,10 @@ class ReportPortalAPIClient:
                 dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
                 return int(dt.timestamp() * 1000)
             except (ValueError, AttributeError) as e:
-                logger.warning(f"Failed to parse timestamp '{timestamp}': {e}")
+                logger.warning("Failed to parse timestamp '%s': %s", timestamp, e)
                 return None
 
+        logger.warning("Timestamp was unexpected type: %s", type(timestamp))
         return None
 
     def normalize_timestamps_in_dict(self, data: Dict[str, Any],

--- a/src/reportportal/rp_api_client.py
+++ b/src/reportportal/rp_api_client.py
@@ -98,7 +98,7 @@ class ReportPortalAPIClient:
         return None
 
     def normalize_timestamps_in_dict(self, data: Dict[str, Any],
-                                     timestamp_fields: List[str] = None) -> Dict[str, Any]:
+                                     timestamp_fields: Optional[List[str]] = None) -> Dict[str, Any]:
         """
         Normalize timestamp fields in a dictionary.
 

--- a/src/reportportal/rp_api_client.py
+++ b/src/reportportal/rp_api_client.py
@@ -46,7 +46,6 @@ class ReportPortalAPIClient:
             url: ReportPortal URL (e.g., https://reportportal.example.com)
             project: ReportPortal project name
             token: ReportPortal API token
-            logger: Optional logger instance (if not provided, creates a default logger)
         """
         self.url = url
         self.project = project

--- a/src/reportportal/rp_api_client.py
+++ b/src/reportportal/rp_api_client.py
@@ -92,10 +92,10 @@ class ReportPortalAPIClient:
                 dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
                 return int(dt.timestamp() * 1000)
             except (ValueError, AttributeError) as e:
-                logger.warning("Failed to parse timestamp '%s': %s", timestamp, e)
+                logger.warning("Failed to parse timestamp '{}': {}", timestamp, e)
                 return None
 
-        logger.warning("Timestamp was unexpected type: %s", type(timestamp))
+        logger.warning("Timestamp was unexpected type: {}", type(timestamp))
         return None
 
     def normalize_timestamps_in_dict(self, data: Dict[str, Any],

--- a/tests/unit/test_rp_api_client.py
+++ b/tests/unit/test_rp_api_client.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for ReportPortal API Client timestamp normalization.
+"""
+
+import pytest
+from reportportal.rp_api_client import ReportPortalAPIClient
+
+
+class TestTimestampNormalization:
+    """Test timestamp normalization for API format changes."""
+
+    def test_normalize_timestamp_from_integer(self):
+        """Test normalizing Unix milliseconds (old format)."""
+        timestamp_ms = 1640000000000
+        result = ReportPortalAPIClient.normalize_timestamp(timestamp_ms)
+        assert result == 1640000000000
+        assert isinstance(result, int)
+
+    def test_normalize_timestamp_from_float(self):
+        """Test normalizing Unix milliseconds as float."""
+        timestamp_ms = 1640000000000.0
+        result = ReportPortalAPIClient.normalize_timestamp(timestamp_ms)
+        assert result == 1640000000000
+        assert isinstance(result, int)
+
+    def test_normalize_timestamp_from_iso_string(self):
+        """Test normalizing ISO format string (new format)."""
+        # Without timezone, assumes local time
+        iso_timestamp = "2021-12-20T13:33:20"
+        result = ReportPortalAPIClient.normalize_timestamp(iso_timestamp)
+        # Verify it returns a valid integer timestamp
+        assert isinstance(result, int)
+        assert result > 0
+
+    def test_normalize_timestamp_from_iso_string_with_z(self):
+        """Test normalizing ISO format string with Z suffix."""
+        # 2021-12-20 13:33:20 UTC = 1640007200000ms
+        iso_timestamp = "2021-12-20T13:33:20Z"
+        result = ReportPortalAPIClient.normalize_timestamp(iso_timestamp)
+        assert result == 1640007200000
+        assert isinstance(result, int)
+
+    def test_normalize_timestamp_from_iso_string_with_timezone(self):
+        """Test normalizing ISO format string with timezone."""
+        # 2021-12-20 13:33:20 UTC = 1640007200000ms
+        iso_timestamp = "2021-12-20T13:33:20+00:00"
+        result = ReportPortalAPIClient.normalize_timestamp(iso_timestamp)
+        assert result == 1640007200000
+        assert isinstance(result, int)
+
+    def test_normalize_timestamp_none(self):
+        """Test normalizing None timestamp."""
+        result = ReportPortalAPIClient.normalize_timestamp(None)
+        assert result is None
+
+    def test_normalize_timestamp_invalid_string(self):
+        """Test normalizing invalid timestamp string."""
+        result = ReportPortalAPIClient.normalize_timestamp("invalid")
+        assert result is None
+
+    def test_normalize_timestamps_in_dict(self):
+        """Test normalizing timestamps in a dictionary."""
+        client = ReportPortalAPIClient("http://example.com", "project", "token")
+
+        data = {
+            'id': 'launch-123',
+            'name': 'Test Launch',
+            'startTime': '2021-12-20T13:33:20+00:00',
+            'endTime': 1640010000000,  # Mixed formats
+            'other_field': 'value'
+        }
+
+        result = client.normalize_timestamps_in_dict(data)
+
+        assert result['id'] == 'launch-123'
+        assert result['name'] == 'Test Launch'
+        assert result['startTime'] == 1640007200000  # Converted from ISO
+        assert result['endTime'] == 1640010000000  # Already in milliseconds
+        assert result['other_field'] == 'value'
+
+    def test_normalize_timestamps_custom_fields(self):
+        """Test normalizing custom timestamp fields."""
+        client = ReportPortalAPIClient("http://example.com", "project", "token")
+
+        data = {
+            'createdAt': '2021-12-20T13:33:20+00:00',
+            'updatedAt': '2021-12-20T14:33:20+00:00',
+        }
+
+        result = client.normalize_timestamps_in_dict(data, ['createdAt', 'updatedAt'])
+
+        assert result['createdAt'] == 1640007200000
+        assert result['updatedAt'] == 1640010800000
+
+    def test_normalize_timestamps_missing_fields(self):
+        """Test normalizing with missing timestamp fields."""
+        client = ReportPortalAPIClient("http://example.com", "project", "token")
+
+        data = {
+            'id': 'launch-123',
+            'name': 'Test Launch',
+        }
+
+        # Should not raise error if fields don't exist
+        result = client.normalize_timestamps_in_dict(data)
+
+        assert result['id'] == 'launch-123'
+        assert result['name'] == 'Test Launch'
+        assert 'startTime' not in result
+        assert 'endTime' not in result

--- a/tests/unit/test_rp_api_client.py
+++ b/tests/unit/test_rp_api_client.py
@@ -2,7 +2,6 @@
 Unit tests for ReportPortal API Client timestamp normalization.
 """
 
-import pytest
 from reportportal.rp_api_client import ReportPortalAPIClient
 
 


### PR DESCRIPTION
ReportPortal API changed from Unix milliseconds to ISO format strings. Added normalization layer in API client to support both formats for backward compatibility.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

fixes #7

Signed-off-by: Zdenek Kraus <zkraus@redhat.com>

> [!NOTE]
> Piggibagged a removal of optional logged that was superseded by using loguru. Even thou it is not related to this fix, it would create too much overhead to split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses now normalise timestamps to a consistent Unix epoch milliseconds format, accepting ISO‑8601 strings (including Z/UTC) and numeric epoch values. Invalid or missing timestamps are handled gracefully and will not break responses.

* **Tests**
  * Added unit tests covering timestamp normalisation across various input formats, selective field normalisation, missing-field behaviour and error‑tolerant handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->