### PR TITLE
fix: add test_case_id to prevent RP history merging

### DIFF
--- a/src/reportportal/reportportal_client_wrapper.py
+++ b/src/reportportal/reportportal_client_wrapper.py
@@ -248,6 +248,7 @@ class ReportPortalClientWrapper:
                        attributes: Optional[List[Dict]] = None,
                        description: Optional[str] = None,
                        code_ref: Optional[str] = None,
+                       test_case_id: Optional[str] = None,
                        retry: bool = False,
                        retry_of: Optional[str] = None) -> str:
         """
@@ -260,6 +261,7 @@ class ReportPortalClientWrapper:
             attributes: Test case attributes
             description: Test case description
             code_ref: Code reference for the test (e.g., "path/to/test.py::test_name")
+            test_case_id: Explicit test case identifier for RP history matching
             retry: If True, marks this test case as a retry of a previous attempt
             retry_of: UUID of the original test item this retry references (RP 25.x)
 
@@ -269,7 +271,7 @@ class ReportPortalClientWrapper:
         if self.dry_run:
             mock_id = self._generate_mock_id()
             logger.info(f"[DRY-RUN] Would start test case '{name}' with ID: {mock_id}")
-            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}, Retry of: {retry_of}")
+            logger.info(f"[DRY-RUN] Parent: {parent_id}, Code ref: {code_ref}, Test case id: {test_case_id}, Retry: {retry}, Retry of: {retry_of}")
             return mock_id
 
         if not self.client:
@@ -284,11 +286,12 @@ class ReportPortalClientWrapper:
                 description=description,
                 parent_item_id=parent_id,
                 code_ref=code_ref,
+                test_case_id=test_case_id,
                 retry=retry,
                 retry_of=retry_of
             )
             logger.debug(f"Started test case '{name}' with ID: {case_id}")
-            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}, Retry: {retry}, Retry of: {retry_of}")
+            logger.debug(f"Parent: {parent_id}, Code ref: {code_ref}, Test case id: {test_case_id}, Retry: {retry}, Retry of: {retry_of}")
             return case_id
         except Exception as e:
             logger.error(f"Failed to start test case '{name}': {e}")

--- a/src/reportportal/writer.py
+++ b/src/reportportal/writer.py
@@ -235,7 +235,8 @@ class RPWriter:
         # Process all test cases in the suite
         for case_data, case_result in zip(suite_data['test_cases'], case_results):
             case_runtime = self._process_test_case(
-                case_data, case_result, suite_id, suite_timestamp + suite_runtime
+                case_data, case_result, suite_id, suite_timestamp + suite_runtime,
+                suite_name=suite_data['name']
             )
             # Disabling suite_runtime tally, due to Interrupted test cases
             # because of parallel run, total runtime is larger than actual time
@@ -248,7 +249,8 @@ class RPWriter:
             attributes=suite_attrs
         )
     
-    def _create_failed_attempts(self, test_name: str, case_result,
+    def _create_failed_attempts(self, test_name: str, test_case_id: str,
+                               case_result,
                                suite_id: str, start_time: int, rerun_duration: int) -> str:
         """
         Create all failed rerun attempts before the final test result.
@@ -257,7 +259,8 @@ class RPWriter:
         are retries referencing the original via retry_of (RP 25.x).
 
         Args:
-            test_name: Full test case name
+            test_name: Test display name and code reference (e.g. "tests/foo.py::test_bar")
+            test_case_id: Suite-qualified identifier for RP history matching (e.g. "smoke: tests/foo.py::test_bar")
             case_result: Filtered case property result
             suite_id: Parent suite ID
             start_time: Test case start time
@@ -277,6 +280,7 @@ class RPWriter:
                 attributes=case_result.properties,
                 description=case_result.description,
                 code_ref=test_name,
+                test_case_id=test_case_id,
                 retry=not is_original,
                 retry_of=None if is_original else original_id
             )
@@ -297,7 +301,8 @@ class RPWriter:
         return original_id
 
     def _process_test_case(self, case_data: dict, case_result,
-                           suite_id: str, start_time: int) -> int:
+                           suite_id: str, start_time: int,
+                           suite_name: str = "") -> int:
         """
         Process a single test case.
 
@@ -306,13 +311,17 @@ class RPWriter:
             case_result: Pre-filtered case property result
             suite_id: Parent suite ID
             start_time: Test case start time
+            suite_name: Parent suite name, used to qualify code_ref
 
         Returns:
             Test case runtime in milliseconds
         """
 
-        # Generate test case name (pytest-style)
+        # Generate test name (pytest-style)
         test_name = f"{case_data['converted_classname']}::{case_data['name']}"
+
+        # Suite-qualified test_case_id for RP history matching
+        test_case_id = f"{suite_name}: {test_name}" if suite_name else test_name
 
         # Create failed rerun attempts before the final result
         original_id = None
@@ -320,7 +329,7 @@ class RPWriter:
         if case_result.reruns > 0:
             rerun_duration = case_data['time'] // (case_result.reruns + 1)
             original_id = self._create_failed_attempts(
-                test_name, case_result, suite_id, start_time, rerun_duration
+                test_name, test_case_id, case_result, suite_id, start_time, rerun_duration
             )
             final_start_time = start_time + (case_result.reruns * rerun_duration)
 
@@ -332,6 +341,7 @@ class RPWriter:
             attributes=case_result.properties,
             description=case_result.description,
             code_ref=test_name,
+            test_case_id=test_case_id,
             retry=original_id is not None,
             retry_of=original_id
         )

--- a/tests/unit/test_reportportal_client_wrapper.py
+++ b/tests/unit/test_reportportal_client_wrapper.py
@@ -230,6 +230,7 @@ class TestReportPortalClientWrapper:
             description="Case description",
             parent_item_id="suite_456",
             code_ref=None,
+            test_case_id=None,
             retry=False,
             retry_of=None
         )
@@ -258,6 +259,7 @@ class TestReportPortalClientWrapper:
             description="Case description",
             parent_item_id="suite_456",
             code_ref="path/to/test.py::test_name",
+            test_case_id=None,
             retry=False,
             retry_of=None
         )


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
  - Added `test_case_id` parameter to `start_test_case()` in the RP client wrapper                                                                                                                                                 
  - Writer now builds a suite-qualified `test_case_id` (`{suite_name}: {test_path}`) so ReportPortal tracks tests under different suites as distinct items in history                                                              
  - Fixes duplicate history entries when the same test runs in multiple suites within one launch (e.g. smoke, acceptance, fullsuite)

Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-test-case identification support to ReportPortal integration, enabling improved history matching and test case tracking.
  * Introduced auto-analysis trigger functionality with dry-run capability for automatic test result analysis.

* **Refactor**
  * Enhanced test case processing to propagate suite-level context and improve ReportPortal history linkage.
  * Improved failed attempt handling with proper test identification for accurate retry tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->