### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -69,7 +69,7 @@ jobs:
           image: ${{ env.IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
           layers: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           containerfiles: |

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -70,7 +70,7 @@ jobs:
           image: ${{ env.IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
           layers: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           build-args: |
             VERSION=${{ steps.set-version.outputs.version }}
           containerfiles: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded container image build support to include PowerPC 64-bit (ppc64le) architecture alongside existing AMD64 and ARM64 platforms, enabling broader CPU compatibility for main and release deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-rptool/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->