### PR TITLE
fix(query): use SUITE type filter in test target

### DIFF
--- a/src/reportportal/rp_query.py
+++ b/src/reportportal/rp_query.py
@@ -478,7 +478,7 @@ def _resolve_test_target(client: 'ReportPortalAPIClient', launch_id: str, target
     # TODO: rewrite to use fetch_test_items once it supports additional filters (see https://github.com/Kuadrant/testsuite-rptool/issues/2)
     parent_items = client.get_test_items(
         launch_id,
-        filters={'filter.eq.name': target_name, 'filter.eq.type': 'TEST'}
+        filters={'filter.eq.name': target_name, 'filter.eq.type': 'SUITE'}
     )
     if not parent_items:
         return None


### PR DESCRIPTION
PR description:
  ## Summary
  - Fix `--test-target` filter in `rptool query` failing with "No test target found"
  - `_resolve_test_target` was filtering by `type=TEST` but test targets are `SUITE` type items in ReportPortal

  ## Test plan
  - [x] `rptool query --launch-name "nightly-all #609" --test-target kuadrant --status FAILED --names-only` returns expected results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved test target resolution to correctly identify suite-type items in ReportPortal instead of test-type items, ensuring more accurate target selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-rptool/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->